### PR TITLE
Fix email address leak in profile DTO

### DIFF
--- a/internal/repository/models.go
+++ b/internal/repository/models.go
@@ -136,6 +136,10 @@ func (u *User) ToResponse() *dto.UserResponse {
 }
 
 func (u *User) ToProfileResponse(stats *UserStats) *dto.UserProfileResponse {
+	var dtoEmail = ""
+	if u.EmailPublic {
+		dtoEmail = u.Email
+	}
 	return &dto.UserProfileResponse{
 		ID:                 u.ID,
 		Username:           u.Username,
@@ -156,7 +160,7 @@ func (u *User) ToProfileResponse(stats *UserStats) *dto.UserProfileResponse {
 		Website:            u.Website,
 		DmsEnabled:         u.DmsEnabled,
 		EpisodeProgress:    u.EpisodeProgress,
-		Email:              u.Email,
+		Email:              dtoEmail,
 		EmailPublic:        u.EmailPublic,
 		EmailNotifications: u.EmailNotifications,
 		HomePage:           u.HomePage,


### PR DESCRIPTION
The system was sending the email address as part of the profile DTO whether the public flag was set or not.

This would make scraping all profiles emails trivial, regardless of the privacy setting.

This makes the DTO only send the email address if public is set.